### PR TITLE
Moved lesson order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ NOTE: This is *not* Carpentries boilerplate! Please read carefully.
      snippet in episode 12 is included using `{% include /snippets/12/info.snip %}`.
 
 3. Edit `_config_options.yml` in your snippets folder. These options set such things as the address
-   of the host to login to, definitions of the command prompt, and scheduler names.
+   of the host to login to, definitions of the command prompt, and scheduler names. You can also 
+   change the order of the episodes, or omit episodes, by editing the configuration block 
+   under `episode_names` in this file.
 
 4. Set the environment variable `HPC_JEKYLL_CONFIG` to the relative path of the configuration file
    in your snippets folder:
@@ -114,7 +116,8 @@ set in the snippet library.
 The following list of items is meant as a guide on what content should go where in this repo. This
 should work as a guide where you can contribute. If a bullet point is prefixed by a file name, this
 is the lesson where the listed content should go into. This document is meant as a concept map
-converted into a flow of learning goals and questions.
+converted into a flow of learning goals and questions. Note, again, that it is possible, when 
+building your actual lesson, to re-order these files, or omit one or more of them.
 
 * Prelude
     * User profiles (academic and/or commercial) of cluster users

--- a/_config.yml
+++ b/_config.yml
@@ -150,3 +150,14 @@ exclude:
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility
+

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
@@ -53,3 +53,13 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/_config_options.yml
@@ -63,3 +63,4 @@ episode_order:
   - 16-parallel
   - 17-resources
   - 18-responsibility
+

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
@@ -54,3 +54,13 @@ sched:
   info: "pbsnodes -a"
   comment: "#PBS"
   hist: "qstat -x"
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/_config_options.yml
@@ -64,3 +64,4 @@ episode_order:
   - 16-parallel
   - 17-resources
   - 18-responsibility
+

--- a/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
@@ -53,3 +53,13 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility

--- a/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/_config_options.yml
@@ -63,3 +63,4 @@ episode_order:
   - 16-parallel
   - 17-resources
   - 18-responsibility
+

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
@@ -53,3 +53,13 @@ sched:
   info: "sinfo"
   comment: "#SBATCH"
   hist: "sacct -u $USER"
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/_config_options.yml
@@ -63,3 +63,4 @@ episode_order:
   - 16-parallel
   - 17-resources
   - 18-responsibility
+

--- a/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
+++ b/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
@@ -42,3 +42,4 @@ episode_order:
   - 16-parallel
   - 17-resources
   - 18-responsibility
+

--- a/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
+++ b/_includes/snippets_library/UCL_Myriad_sge/_config_options.yml
@@ -32,3 +32,13 @@ sched:
   info: "qhost"
   comment: "#$ "
   hist: "jobhist"
+
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility


### PR DESCRIPTION
Lesson order is now specified in the site-specific _config_options.yml file.  Updated the top-level README to reflect this. Did not actually re-order the lessons.

Closes #230.