### PR TITLE
Some minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ files/*.tsv
 Gemfile.lock
 scratch/
 .vendor
+.bundle

--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,16 @@ sched:
   comment: "#SBATCH"
   hist: "sacct -u yourUsername"
 
+episode_order:
+  - 11-hpc-intro
+  - 12-cluster
+  - 13-scheduler
+  - 14-modules
+  - 15-transferring-files
+  - 16-parallel
+  - 17-resources
+  - 18-responsibility
+
 #------------------------------------------------------------
 # Values for this lesson
 #------------------------------------------------------------
@@ -150,14 +160,4 @@ exclude:
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge
-
-episode_order:
-  - 11-hpc-intro
-  - 12-cluster
-  - 13-scheduler
-  - 14-modules
-  - 15-transferring-files
-  - 16-parallel
-  - 17-resources
-  - 18-responsibility
 

--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -113,9 +113,10 @@ bottom of the directory tree rooted at the folder name you provided.
 ```
 {: .bash}
 
-> Caution: For a large directory &mdash; either in size or number of files &mdash; copying
+> ## Caution
+> For a large directory &mdash; either in size or number of files &mdash; copying
 > with `-r` can take a long time to complete.
-{: .warning}
+{: .callout}
 
 
 ## What's in a `/`?


### PR DESCRIPTION
* Serving the content locally creates a `.bundle` directory in the root that should not be tracked, added this to `.gitignore`
* We use `{: .warning}` somewhere but this is not valid lesson syntax and does not render, replace with `{: .callout}` and an appropriate heading
* For lesson rendering in GitHub, instructions are to copy-paste from site configuration into `_config.yml`. Episode ordering is part of site configuration so should appear alongside everything else