### PR TITLE
Use language-bash not bash in formatting

### DIFF
--- a/_episodes/12-cluster.md
+++ b/_episodes/12-cluster.md
@@ -82,7 +82,7 @@ username and the remote computer you can reach from the outside world, {{ site.r
 ```
 {{ site.local.prompt }} ssh {{ site.remote.user }}@{{ site.remote.login }}
 ```
-{: .bash}
+{: .language-bash}
 
 Remember to replace `{{ site.remote.user }}` with your username or the one supplied by the
 instructors. You may be asked for your password. Watch out: the characters you type after the
@@ -100,7 +100,7 @@ notice that the current hostname is also part of our prompt!)
 ```
 {{ site.remote.prompt }} hostname
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 {{ site.remote.host }}
@@ -125,7 +125,7 @@ notice that the current hostname is also part of our prompt!)
 > > ```
 > > {{ site.remote.prompt }} pwd
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > > The deepest layer should differ: {{ site.remote.user }} is uniquely yours. Are there
 > > > differences in the path at higher levels?
@@ -137,7 +137,7 @@ notice that the current hostname is also part of our prompt!)
 > > ```
 > > {{ site.remote.prompt }} ls -a
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > At a minimum, this will show the current directory as `.`, and the parent directory as `..`.
 > >
@@ -185,7 +185,7 @@ For example, we can view all of the worker nodes with the `{{ site.sched.info }}
 ```
 {{ site.remote.prompt }} {{ site.sched.info }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/cluster/queue-info.snip %}
 
@@ -217,7 +217,7 @@ it is more common for nodes to connect to a shared, remote fileserver or cluster
 > {{ site.remote.prompt }} exit
 > {{ site.local.prompt }}
 > ```
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > >
@@ -229,20 +229,20 @@ it is more common for nodes to connect to a shared, remote fileserver or cluster
 > >   {{ site.local.prompt }} nproc --all
 > >   {{ site.local.prompt }} free -m
 > >   ```
-> >   {: .bash}
+> >   {: .language-bash}
 > >
 > > * Read from `/proc`
 > >   ```
 > >   {{ site.local.prompt }} cat /proc/cpuinfo
 > >   {{ site.local.prompt }} cat /proc/meminfo
 > >   ```
-> >   {: .bash}
+> >   {: .language-bash}
 > >
 > > * Run system monitor
 > >   ```
 > >   {{ site.local.prompt }} htop
 > >   ```
-> >   {: .bash}
+> >   {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -257,7 +257,7 @@ it is more common for nodes to connect to a shared, remote fileserver or cluster
 > > {{ site.remote.prompt }} nproc --all
 > > {{ site.remote.prompt }} free -m
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > You can get more information about the processors using `lscpu`,
 > > and a lot of detail about the memory by reading the file `/proc/meminfo`:
@@ -265,7 +265,7 @@ it is more common for nodes to connect to a shared, remote fileserver or cluster
 > > ```
 > > {{ site.remote.prompt }} less /proc/meminfo
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > You can also explore the available filesystems using `df` to show **d**isk **f**ree space.
 > > The `-h` flag renders the sizes in a human-friendly format, i.e., GB instead of B. The **t**ype
@@ -274,7 +274,7 @@ it is more common for nodes to connect to a shared, remote fileserver or cluster
 > > ```
 > > {{ site.remote.prompt }} df -Th
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > > The local filesystems (ext, tmp, xfs, zfs) will depend on whether you're on the same login
 > > > node (or compute node, later on). Networked filesystems (beegfs, cifs, gpfs, nfs, pvfs) will

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -101,7 +101,7 @@ whichever you prefer. Unsure? `nano` is a pretty good, basic choice.
 {{ site.remote.prompt }} chmod +x example-job.sh
 {{ site.remote.prompt }} cat example-job.sh
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 #!/bin/bash
@@ -120,7 +120,7 @@ hostname
 > > ```
 > > {{ site.remote.prompt }} ./example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > > ```
 > > This script is running on {{ site.remote.host }}
 > > ```
@@ -137,7 +137,7 @@ to the scheduler, we use the `{{ site.sched.submit.name }}` command.
 ```
 {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/basic-job-script.snip %}
 
@@ -149,7 +149,7 @@ the *queue*. To check on our job's status, we check the queue using the command
 ```
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/basic-job-status.snip %}
 
@@ -164,7 +164,7 @@ try using it to monitor another job.
 {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 You should see an auto-updating display of your job's status. When it finishes, it will disappear
 from the queue. Press `Ctrl-C` when you want to stop the `watch` command.
@@ -200,7 +200,7 @@ script:
 ```
 {{ site.remote.prompt }} cat example-job.sh
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 #!/bin/bash
@@ -218,7 +218,7 @@ and monitor it:
 ```
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/job-with-name-status.snip %}
 
@@ -275,7 +275,7 @@ about how to make sure that you're using resources effectively in a later episod
 > > ```
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash
@@ -291,7 +291,7 @@ about how to make sure that you're using resources effectively in a later episod
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Why are the {{ site.sched.name }} runtime and `sleep` time not identical?
 > {: .solution}
@@ -306,7 +306,7 @@ minutes.
 ```
 {{ site.remote.prompt }} cat example-job.sh
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 #!/bin/bash
@@ -326,7 +326,7 @@ Submit the job and wait for it to finish. Once it is has finished, check the log
 {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/runtime-exceeded-job.snip %}
 
@@ -351,7 +351,7 @@ to change the walltime so that it runs long enough for you to cancel it before i
 {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/terminate-job-begin.snip %}
 
@@ -363,7 +363,7 @@ prompt indicates that the request to cancel the job was successful.
 # ... Note that it might take a minute for the job to disappear from the queue ...
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/scheduler/terminate-job-cancel.snip %}
 

--- a/_episodes/14-modules.md
+++ b/_episodes/14-modules.md
@@ -66,7 +66,7 @@ To see available software modules, use `module avail`
 ```
 {{ site.remote.prompt }} module avail
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/modules/available-modules.snip %}
 
@@ -79,7 +79,7 @@ so
 ```
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 No Modulefiles Currently Loaded.
@@ -99,7 +99,7 @@ so we can use it to tell us where a particular piece of software is stored.
 ```
 {{ site.remote.prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/modules/missing-python.snip %}
 
@@ -120,7 +120,7 @@ variables we can print it out using `echo`.
 ```
 {{ site.remote.prompt }} echo $PATH
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/modules/python-module-path.snip %}
 
@@ -151,7 +151,7 @@ Let's examine the output of `module avail` more closely.
 ```
 {{ site.remote.prompt }} module avail
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/modules/available-modules.snip %}
 
@@ -169,7 +169,7 @@ Let's examine the output of `module avail` more closely.
 > > {{ site.remote.prompt }} nano python-module.sh
 > > {{ site.remote.prompt }} cat python-module.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash
@@ -183,7 +183,7 @@ Let's examine the output of `module avail` more closely.
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} python-module.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -28,7 +28,7 @@ we'll use later on, from a terminal on your local machine.
 ```
 {{ site.local.prompt }} wget {{ site.url }}{{ site.baseurl }}/files/hpc-intro-data.tar.gz
 ```
-{: .bash}
+{: .language-bash}
 
 > ## `tar.gz`?
 >
@@ -48,14 +48,14 @@ To *upload to* another computer:
 ```
 {{ site.local.prompt }} scp path/to/local/file.txt {{ site.remote.user }}@{{ site.remote.login }}:/path/on/{{ site.remote.name }}
 ```
-{: .bash}
+{: .language-bash}
 
 To *download from* another computer:
 
 ```
 {{ site.local.prompt }} scp {{ site.remote.user }}@{{ site.remote.login }}:/path/on/{{ site.remote.name }}/file.txt path/to/local/
 ```
-{: .bash}
+{: .language-bash}
 
 Note that everything after the `:` is relative to our home directory on the remote computer. We can
 leave it at that if we don't care where the file goes.
@@ -63,7 +63,7 @@ leave it at that if we don't care where the file goes.
 ```
 {{ site.local.prompt }} scp local-file.txt {{ site.remote.user }}@{{ site.remote.login }}:
 ```
-{: .bash}
+{: .language-bash}
 
 > ## Upload a file
 >
@@ -75,7 +75,7 @@ leave it at that if we don't care where the file goes.
 > > ```
 > > {{ site.local.prompt }} scp hpc-intro-data.tar.gz {{ site.remote.user }}@{{ site.remote.login }}:~/
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -97,7 +97,7 @@ leave it at that if we don't care where the file goes.
 > > > {{ site.local.prompt }} ssh {{ site.remote.user }}@{{ site.remote.login }}
 > > > {{ site.remote.prompt }} wget {{ site.url }}{{ site.baseurl }}/files/hpc-intro-data.tar.gz
 > > > ```
-> > > {: .bash}
+> > > {: .language-bash}
 > > {: .solution}
 > >
 > > Did it work? If not, what does the terminal output tell you about what happened?
@@ -111,7 +111,7 @@ bottom of the directory tree rooted at the folder name you provided.
 ```
 {{ site.local.prompt }} scp -r some-local-folder {{ site.remote.user }}@{{ site.remote.login }}:target-directory/
 ```
-{: .bash}
+{: .language-bash}
 
 > ## Caution
 > For a large directory &mdash; either in size or number of files &mdash; copying
@@ -148,7 +148,7 @@ important in other commands, like `rsync`.
 > ```
 > {{ site.local.prompt }} rsync -avzP path/to/local/file.txt {{ site.remote.user }}@{{ site.remote.login }}:directory/path/on/{{ site.remote.name }}/
 > ```
-> {: .bash}
+> {: .language-bash}
 >
 > The `a` (archive) option preserves file timestamps and permissions among other things; the `v`
 > (verbose) option gives verbose output to help monitor the transfer; the `z` (compression) option
@@ -161,7 +161,7 @@ important in other commands, like `rsync`.
 > ```
 > {{ site.local.prompt }} rsync -avzP path/to/local/dir {{ site.remote.user }}@{{ site.remote.login }}:directory/path/on/{{ site.remote.name }}/
 > ```
-> {: .bash}
+> {: .language-bash}
 > 
 > As written, this will place the local directory and its contents under the specified directory on
 > the remote system. If the trailing slash is omitted on the destination, a new directory
@@ -175,7 +175,7 @@ important in other commands, like `rsync`.
 > ```
 > {{ site.local.prompt }} rsync -avzP {{ site.remote.user }}@{{ site.remote.login }}:path/on/{{ site.remote.name }}/file.txt path/to/local/
 > ```
-> {: .bash}
+> {: .language-bash}
 {: .callout}
 
 > ## A note on ports
@@ -192,7 +192,7 @@ important in other commands, like `rsync`.
 > > ```
 > > {{ site.local.prompt }} rsync test.txt {{ site.remote.user }}@{{ site.remote.login }}:
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > > ## Solution
 > > >
@@ -202,7 +202,7 @@ important in other commands, like `rsync`.
 > > > See http://rsync.samba.org/ for updates, bug reports, and answers
 > > > {{ site.local.prompt }} rsync --port=768 test.txt {{ site.remote.user }}@{{ site.remote.login }}:
 > > > ```
-> > > {: .bash}
+> > > {: .language-bash}
 > > {: .solution}
 > {: .challenge}
 {: .callout}
@@ -284,7 +284,7 @@ hpc-intro-data/north-pacific-gyre/NENE01751A.txt
 hpc-intro-data/north-pacific-gyre/NENE01729A.txt
 hpc-intro-data/north-pacific-gyre/NENE02040Z.txt
 ```
-{: .bash}
+{: .language-bash}
 
 This shows a folder containing another folder, which contains a bunch of files. If you've taken The
 Carpentries' Shell lesson recently, these might look familiar. Let's see about that compression,
@@ -294,7 +294,7 @@ using `du` for "**d**isk **u**sage".
 {{ site.remote.prompt }} du -sh hpc-lesson-data.tar.gz
 36K     hpc-intro-data.tar.gz
 ```
-{: .bash}
+{: .language-bash}
 
 > If the filesystem block size is larger than 36 KB, you'll see a larger number: files cannot be
 > smaller than one block.
@@ -321,7 +321,7 @@ When it's done, check the directory size with `du` and compare.
 > > ```
 > > {{ site.remote.prompt }} tar -xvzf hpc-lesson-data.tar.gz
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > > 
 > > ```
 > > hpc-intro-data/
@@ -355,7 +355,7 @@ When it's done, check the directory size with `du` and compare.
 > > {{ site.remote.prompt }} du -sh hpc-lesson-data
 > > 144K    hpc-intro-data
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 >
 > > ## Was the data compressed?
@@ -370,7 +370,7 @@ set a `c` flag instead of `x`, set the archive filename, then provide a director
 ```
 {{ site.local.prompt }} tar -cvzf compressed_data.tar.gz hpc-intro-data
 ```
-{: .bash}
+{: .language-bash}
 
 > ## Working with Windows
 >

--- a/_episodes/16-parallel.md
+++ b/_episodes/16-parallel.md
@@ -56,7 +56,7 @@ Download the Python executable using the following command:
 ```
 {{ site.remote.prompt }} wget {{ site.url }}{{ site.baseurl }}/files/pi.py
 ```
-{: .bash}
+{: .language-bash}
 
 Let's take a quick look inside the file. It is richly commented, and should explain itself
 clearly. Press "q" to exit the pager program (`less`).
@@ -64,7 +64,7 @@ clearly. Press "q" to exit the pager program (`less`).
 ```
 {{ site.remote.prompt }} less pi.py
 ```
-{: .bash}
+{: .language-bash}
 
 > ## What's `pi.py` doing?
 >
@@ -117,7 +117,7 @@ Create a submission file, requesting more than one task on a single node:
 {{ site.remote.prompt }} nano parallel-pi.sh
 {{ site.remote.prompt }} cat parallel-pi.sh
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 #!/bin/bash
@@ -135,7 +135,7 @@ rather than the command line.
 ```
 {{ site.remote.prompt }} {{ site.sched.submit.name }} parallel-pi.sh
 ```
-{: .bash}
+{: .language-bash}
 
 As before, use the status commands to check when your job runs. Use `ls` to locate the
 output file, and examine it. Is it what you expected?

--- a/_episodes/17-resources.md
+++ b/_episodes/17-resources.md
@@ -50,7 +50,7 @@ see how long our job took and what resources were used. We will use `{{ site.sch
 ```
 {{ site.remote.prompt }} {{ site.sched.hist }}
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/resources/account-history.snip %}
 
@@ -60,7 +60,7 @@ get info about a specific job, we change command slightly.
 ```
 {{ site.remote.prompt }} {{ site.sched.hist }} {{ site.sched.flag.histdetail }} 1965
 ```
-{: .bash}
+{: .language-bash}
 
 It will show a lot of info, in fact, every single piece of info collected on your job by
 the scheduler. It may be useful to redirect this information to `less` to make it easier
@@ -69,7 +69,7 @@ to view (use the left and right arrow keys to scroll through fields).
 ```
 {{ site.remote.prompt }} {{ site.sched.hist }} {{ site.sched.flag.histdetail }} 1965 | less
 ```
-{: .bash}
+{: .language-bash}
 
 Some interesting fields include the following:
 
@@ -96,7 +96,7 @@ might look like the following (type `q` to exit `top`):
 ```
 {{ site.remote.prompt }} top
 ```
-{: .bash}
+{: .language-bash}
 
 {% include {{ site.snippets }}/resources/monitor-processes-top.snip %}
 
@@ -121,7 +121,7 @@ they're here to help!
 ```
 {{ site.remote.prompt }} htop
 ```
-{: .bash}
+{: .language-bash}
 
 
 ### `ps`
@@ -131,7 +131,7 @@ To show all processes from your current session, type `ps`.
 ```
 {{ site.remote.prompt }} ps
 ```
-{: .bash}
+{: .language-bash}
 
 ```
   PID TTY          TIME CMD
@@ -147,7 +147,7 @@ you own (regardless of whether they are part of your current session or not), yo
 ```
 {{ site.remote.prompt }} ps ux
 ```
-{: .bash}
+{: .language-bash}
 
 ```
     USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND

--- a/_episodes/18-responsibility.md
+++ b/_episodes/18-responsibility.md
@@ -195,25 +195,25 @@ proportional to the data transferred along that interface.</i>" %}
 > 1. ```
 >    {{ site.local.prompt }} scp -r data {{ site.remote.user }}@{{ site.remote.login }}:~/
 >    ```
->    {: .bash}
+>    {: .language-bash}
 > 2. ```
 >    {{ site.local.prompt }} rsync -ra data {{ site.remote.user }}@{{ site.remote.login }}:~/
 >    ```
->    {: .bash}
+>    {: .language-bash}
 > 3. ```
 >    {{ site.local.prompt }} rsync -raz data {{ site.remote.user }}@{{ site.remote.login }}:~/
 >    ```
->    {: .bash}
+>    {: .language-bash}
 > 4. ```
 >    {{ site.local.prompt }} tar -cvf data.tar data
 >    {{ site.local.prompt }} rsync -raz data.tar {{ site.remote.user }}@{{ site.remote.login }}:~/
 >    ```
->    {: .bash}
+>    {: .language-bash}
 > 5. ```
 >    {{ site.local.prompt }} tar -cvzf data.tar.gz data
 >    {{ site.local.prompt }} rsync -ra data.tar.gz {{ site.remote.user }}@{{ site.remote.login }}:~/
 >    ```
->    {: .bash}
+>    {: .language-bash}
 >
 > > ## Solution
 > >

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -115,7 +115,7 @@ and this will differ from individual to individual!
 >   -evalue 0.0001 -word_size 7  -max_target_seqs 10 -num_threads 1 \
 >   -out output_seq_0.blast -outfmt "6 std stitle staxids sscinames"
 >   ```
->   {: .bash}
+>   {: .language-bash}
 >
 >   where the `\` character tells `bash` that the command continues on the next line. Note that
 >   there will be no output from this alignment if it works correctly).

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/module-load-python.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/module-load-python.snip
@@ -2,4 +2,4 @@
 {{ site.remote.prompt }} module load python
 {{ site.remote.prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/python-ls-dir-command.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/python-ls-dir-command.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} ls /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/python-3.5.2/bin
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/software-dependencies.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/software-dependencies.snip
@@ -3,7 +3,7 @@ To demonstrate, let's use `module list`. `module list` shows all loaded software
 ```
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -22,7 +22,7 @@ Currently Loaded Modules:
 {{ site.remote.prompt }} module load beast
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -48,7 +48,7 @@ So in this case, loading the `beast` module (a bioinformatics software package),
 {{ site.remote.prompt }} module unload beast
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -69,7 +69,7 @@ everything at once, we could run `module purge` (unloads everything).
 ```
 {{ site.remote.prompt }} module purge
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 The following modules were not unloaded:

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/modules/wrong-gcc-version.snip
@@ -10,7 +10,7 @@ In this case, `gcc/5.4.0` has a `(D)` next to it. This indicates that it is the 
 {{ site.remote.prompt }} module load gcc
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Lmod is automatically replacing "intel/2016.4" with "gcc/5.4.0".
@@ -39,7 +39,7 @@ command is to leave in the version number after the `/`.
 {{ site.remote.prompt }} module load gcc/4.8.5
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Inactive Modules:
@@ -63,7 +63,7 @@ program has "inactivated" the module. All this means for us is that if we re-loa
 ```
 {{ site.remote.prompt }} module load gcc/5.4.0
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Activating Modules:

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/print-sched-variables.snip
@@ -12,7 +12,7 @@
 > > {{ site.remote.prompt }} nano example-job.sh
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/runtime-exceeded-job.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/runtime-exceeded-job.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} cat slurm-38193.out
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
@@ -14,13 +14,13 @@
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Then, cancel them all:
 > >
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.del }} -u yourUsername
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/using-nodes-interactively.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/using-nodes-interactively.snip
@@ -5,7 +5,7 @@ cancel an `{{ site.sched.interactive }}` job with `Ctrl-c`.)
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} hostname
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 gra752
@@ -20,7 +20,7 @@ command:
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} -n 2 echo "This job will use 2 CPUs."
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 This job will use 2 CPUs.
@@ -41,7 +41,7 @@ site.sched.interactive }}`:
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} --pty bash
 ```
-{: .bash}
+{: .language-bash}
 
 You should be presented with a bash prompt. Note that the prompt will likely change to reflect your
 new location, in this case the compute node we are logged on. You can also verify this with

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/modules/module-load-python.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/modules/module-load-python.snip
@@ -2,4 +2,4 @@
 {{ site.remote.prompt }} module load anaconda/python3
 {{ site.remote.prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/modules/python-ls-dir-command.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/modules/python-ls-dir-command.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} ls /lustre/sw/anaconda/anaconda3-5.1.0/bin
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/modules/software-dependencies.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/modules/software-dependencies.snip
@@ -6,7 +6,7 @@ source materials science modelling software package.)
 {{ site.remote.prompt }} module load abinit
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modulefiles:
@@ -24,7 +24,7 @@ unloading the `abinit` package.
 {{ site.remote.prompt }} module unload abinit
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modulefiles:
@@ -39,7 +39,7 @@ everything at once, we could run `module purge` (unloads everything).
 {{ site.remote.prompt }} module load abinit
 {{ site.remote.prompt }} module purge
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 No Modulefiles Currently Loaded.

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/modules/wrong-gcc-version.snip
@@ -10,7 +10,7 @@ we type `module load gcc`, this is the copy that will be loaded.
 {{ site.remote.prompt }} module load gcc
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 gcc (GCC) 6.2.0
@@ -28,7 +28,7 @@ To load a non-default module, we need to make add the version number after the `
 ```
 {{ site.remote.prompt }} module load gcc/7.2.0
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 gcc/7.2.0(17):ERROR:150: Module 'gcc/7.2.0' conflicts with the currently loaded module(s) 'gcc/6.2.0'
@@ -45,7 +45,7 @@ default version before we load the new version.
 {{ site.remote.prompt }} module load gcc/7.2.0
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 gcc (GCC) 7.2.0
@@ -67,7 +67,7 @@ rather than unloading one version before loading another. The equivalent of the 
 {{ site.remote.prompt }} module swap gcc gcc/7.2.0
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 gcc (GCC) 6.2.0

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/print-sched-variables.snip
@@ -13,7 +13,7 @@
 > > {{ site.remote.prompt }} nano example-job.sh
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/runtime-exceeded-job.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/runtime-exceeded-job.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} cat example-job.sh.e387798
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/using-nodes-interactively.snip
+++ b/_includes/snippets_library/EPCC_Cirrus_pbs/scheduler/using-nodes-interactively.snip
@@ -5,7 +5,7 @@ an interactive job that uses a single core:
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} {{ site.sched.flag.interactive }}
 ```
-{: .bash}
+{: .language-bash}
 
 You should be presented with a bash prompt. Note that the prompt will likely change to reflect your
 new location, in this case the worker node we are logged on. You can also verify this with

--- a/_includes/snippets_library/NIST_CTCMS_slurm/modules/module-load-python.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/modules/module-load-python.snip
@@ -2,4 +2,4 @@
 {{ site.remote.prompt }} module load python
 {{ site.remote.prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/modules/python-ls-dir-command.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/modules/python-ls-dir-command.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} ls /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/python-3.5.2/bin
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/modules/software-dependencies.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/modules/software-dependencies.snip
@@ -3,7 +3,7 @@ To demonstrate, let's use `module list`. `module list` shows all loaded software
 ```
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -22,7 +22,7 @@ Currently Loaded Modules:
 {{ site.remote.prompt }} module load beast
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -48,7 +48,7 @@ So in this case, loading the `beast` module (a bioinformatics software package),
 {{ site.remote.prompt }} module unload beast
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -69,7 +69,7 @@ everything at once, we could run `module purge` (unloads everything).
 ```
 {{ site.remote.prompt }} module purge
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 The following modules were not unloaded:

--- a/_includes/snippets_library/NIST_CTCMS_slurm/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/modules/wrong-gcc-version.snip
@@ -10,7 +10,7 @@ In this case, `gcc/5.4.0` has a `(D)` next to it. This indicates that it is the 
 {{ site.remote.prompt }} module load gcc
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Lmod is automatically replacing "intel/2016.4" with "gcc/5.4.0".
@@ -39,7 +39,7 @@ command is to leave in the version number after the `/`.
 {{ site.remote.prompt }} module load gcc/4.8.5
 {{ site.remote.prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Inactive Modules:
@@ -63,7 +63,7 @@ program has "inactivated" the module. All this means for us is that if we re-loa
 ```
 {{ site.remote.prompt }} module load gcc/5.4.0
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Activating Modules:

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/print-sched-variables.snip
@@ -12,7 +12,7 @@
 > > {{ site.remote.prompt }} nano example-job.sh
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/runtime-exceeded-job.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/runtime-exceeded-job.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} cat slurm-38193.out
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
@@ -14,13 +14,13 @@
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Then, cancel them all:
 > >
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.del }} -u yourUsername
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/using-nodes-interactively.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/using-nodes-interactively.snip
@@ -5,7 +5,7 @@ cancel an `{{ site.sched.interactive }}` job with `Ctrl-c`.)
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} hostname
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 {{ site.sched.node }}
@@ -20,7 +20,7 @@ command:
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} -n 2 echo "This job will use 2 CPUs."
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 This job will use 2 CPUs.
@@ -40,7 +40,7 @@ site.sched.interactive }}`:
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} --pty bash
 ```
-{: .bash}
+{: .language-bash}
 
 You should be presented with a bash prompt. Note that the prompt will likely change to reflect your
 new location, in this case the compute node we are logged on. You can also verify this with

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/module-load-python.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/module-load-python.snip
@@ -2,4 +2,4 @@
 {{ site.host_prompt }} module load Python/3.7.2-GCCcore-8.2.0
 {{ site.host_prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/python-ls-dir-command.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/python-ls-dir-command.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.host_prompt }} ls /cluster/software/Python/3.8.2-GCCcore-9.3.0/bin
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/software-dependencies.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/software-dependencies.snip
@@ -3,7 +3,7 @@ To demonstrate, let's use `module list`. `module list` shows all loaded software
 ```
 {{ site.host_prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 ```
 
 Currently Loaded Modules:
@@ -21,7 +21,7 @@ Currently Loaded Modules:
 {{ site.host_prompt }} module load Beast/2.5.2-GCC-8.2.0-2.31.1
 {{ site.host_prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -43,7 +43,7 @@ So in this case, loading the `beast` module (a bioinformatics software package),
 {{ site.host_prompt }} module unload Beast/2.5.2-GCC-8.2.0-2.31.1
 {{ site.host_prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modules:
@@ -64,7 +64,7 @@ If we wanted to unload everything at once, we could run `module purge` (unloads 
 ```
 {{ site.host_prompt }} module purge
 ```
-{: .bash}
+{: .language-bash}
 ```
 The following modules were not unloaded:
   (Use "module --force purge" to unload all):

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/modules/wrong-gcc-version.snip
@@ -9,7 +9,7 @@ On SAGA and Fram we do not have default modules and we must use the full name to
 ```
 {{ site.host_prompt }} module load gcc
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Lmod has detected the following error:  The following module(s) are unknown: "gcc"
@@ -29,5 +29,5 @@ To load a software module we must specify the full module name
 {{ site.host_prompt }} module load  GCC/8.2.0-2.31.1
 {{ site.host_prompt }} gcc --version
 ```
-{: .bash}
+{: .language-bash}
 ```

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/resources/bench.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/resources/bench.snip
@@ -5,7 +5,7 @@
 > ```
 > fastqc name_of_fastq_file
 > ```
-> {: .bash}
+> {: .language-bash}
 > 
 > The `fastqc` command is provided by the `fastqc` module. You'll need to figure out a good amount
 > of resources to ask for for this first "test run". You might also want to have the scheduler 

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/scheduler/print-sched-variables.snip
@@ -12,7 +12,7 @@
 > > {{ site.remote.prompt }} nano example-job.sh
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash

--- a/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/scheduler/using-nodes-interactively.snip
+++ b/_includes/snippets_library/Norway_SIGMA2_SAGA_slurm/scheduler/using-nodes-interactively.snip
@@ -4,7 +4,7 @@
 ```
 {{ site.host_prompt }} srun hostname
 ```
-{: .bash}
+{: .language-bash}
 ```
 gra752
 ```
@@ -17,7 +17,7 @@ uses 2 CPUs for instance, we could use the following command:
 ```
 {{ site.host_prompt }} srun -n 2 echo "This job will use 2 CPUs."
 ```
-{: .bash}
+{: .language-bash}
 ```
 This job will use 2 CPUs.
 This job will use 2 CPUs.
@@ -35,7 +35,7 @@ Fortunately, SLURM makes it easy to start an interactive job with `srun`:
 ```
 {{ site.host_prompt }} srun --pty bash
 ```
-{: .bash}
+{: .language-bash}
 
 You should be presented with a bash prompt. Note that the prompt will likely change to reflect your
 new location, in this case the compute node we are logged on. You can also verify this with

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/module-load-python.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/module-load-python.snip
@@ -2,4 +2,4 @@
 {{ site.remote.prompt }} module load python
 {{ site.remote.prompt }} which python3
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/python-ls-dir-command.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/python-ls-dir-command.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} ls /shared/ucl/apps/python/3.6.3/gnu-4.9.2/bin
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/software-dependencies.snip
@@ -5,7 +5,7 @@ an engineering simulation product.)
 ```
 {{ site.remote.prompt }} module load ansys
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 ansys/2019.r3(73):ERROR:151: Module 'ansys/2019.r3' depends on one of the module(s) 'giflib/5.1.1'
@@ -22,7 +22,7 @@ Let's load the `giflib` module:
 ```
 {{ site.remote.prompt }} module load giflib
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 giflib/5.1.1(18):ERROR:151: Module 'giflib/5.1.1' depends on one of the module(s) 'gcc-libs/4.9.2'
@@ -38,7 +38,7 @@ first, then load `giflib`, and then finally load `ansys`.
 {{ site.remote.prompt }} module load giflib/5.1.1
 {{ site.remote.prompt }} module load ansys
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 ~/Scratch/.config is configured
@@ -59,7 +59,7 @@ If we wanted to unload everything at once (all modules), we could run `module pu
 {{ site.remote.prompt }} module purge
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 No Modulefiles Currently Loaded.

--- a/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/modules/wrong-gcc-version.snip
@@ -4,7 +4,7 @@ e.g.
 ```
 {{ site.remote.prompt }} module avail stata
 ```
-{: .bash}
+{: .language-bash}
  
 ```
 ------------------------------------- /shared/ucl/apps/modulefiles/applications --------------------------------------
@@ -22,7 +22,7 @@ Let's see which versions we have access to.
 ```
 {{ site.remote.prompt }} module avail matlab
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 ------------------------------------- /shared/ucl/apps/modulefiles/applications --------------------------------------
@@ -41,7 +41,7 @@ In this case, we don't see this, so we will have to load matlab and see what we 
 ```
 {{ site.remote.prompt }} module load matlab
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 matlab/full/r2019b/9.7(99):ERROR:151: Module 'matlab/full/r2019b/9.7' depends on one of the module(s) 'gcc-libs/4.9.2'
@@ -61,7 +61,7 @@ Suppose we decide to load an earlier version of Matlab, e.g. r2017a/9.2.
 {{ site.remote.prompt }} module purge
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 No Modulefiles Currently Loaded.
@@ -71,7 +71,7 @@ No Modulefiles Currently Loaded.
 ```
 {{ site.remote.prompt }} module load matlab/full/r2017a/9.2
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 matlab/full/r2017a/9.2(96):ERROR:151: Module 'matlab/full/r2017a/9.2' depends on one of the module(s) 'gcc-libs/4.9.2'
@@ -83,7 +83,7 @@ matlab/full/r2017a/9.2(96):ERROR:102: Tcl command execution failed: prereq gcc-l
 {{ site.remote.prompt }} module load gcc-libs/4.9.2
 {{ site.remote.prompt }} module load matlab/full/r2017a/9.2
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 matlab/full/r2017a/9.2(97):ERROR:151: Module 'matlab/full/r2017a/9.2' depends on one of the module(s) 'xorg-utils/X11R7.7'
@@ -95,7 +95,7 @@ matlab/full/r2017a/9.2(97):ERROR:102: Tcl command execution failed: prereq xorg-
 {{ site.remote.prompt }} module load xorg-utils/X11R7.7
 {{ site.remote.prompt }} module load matlab/full/r2017a/9.2
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 ~/.matlab is a symbolic link pointing to /home/yourUsername/Scratch/.matlab
@@ -107,7 +107,7 @@ Matlab setup complete type matlab to start Matlab.
 ```
 {{ site.remote.prompt }} matlab -nodisplay -nosplash -nodesktop
 ```
-{: .bash}
+{: .language-bash}
 
 ```
                                                < M A T L A B (R) >
@@ -130,7 +130,7 @@ Currently, we have loaded `matlab/full/r2017a/9.2`. Let's try also loading
 ```
 {{ site.remote.prompt }} module load matlab/full/r2015b/8.6
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 matlab/full/r2015b/8.6(108):ERROR:150: Module 'matlab/full/r2015b/8.6' conflicts with the currently loaded module(s) 'matlab/full/r2017a/9.2'
@@ -145,21 +145,21 @@ If we do indeed wish to load version r2015b/8.6, we can say
 {{ site.remote.prompt }} module unload matlab/full/r2017a/9.2
 {{ site.remote.prompt }} module load matlab/full/r2015b/8.6
 ```
-{: .bash}
+{: .language-bash}
 
 or, in one step:
 
 ```
 {{ site.remote.prompt }} module swap matlab matlab/full/r2015b/8.6
 ```
-{: .bash}
+{: .language-bash}
 
 Check that this module has been loaded:
 
 ```
 {{ site.remote.prompt }} module list
 ```
-{: .bash}
+{: .language-bash}
 
 ```
 Currently Loaded Modulefiles:

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/print-sched-variables.snip
@@ -13,7 +13,7 @@
 > > {{ site.remote.prompt }} nano example-job.sh
 > > {{ site.remote.prompt }} cat example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > #!/bin/bash

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/runtime-exceeded-job.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/runtime-exceeded-job.snip
@@ -1,4 +1,4 @@
 ```
 {{ site.remote.prompt }} cat long_job.o*
 ```
-{: .bash}
+{: .language-bash}

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
@@ -14,13 +14,13 @@
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > Then, cancel them all:
 > >
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.del }} -u yourUsername
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/using-nodes-interactively.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/using-nodes-interactively.snip
@@ -6,7 +6,7 @@ complete.
 ```
 {{ site.remote.prompt }} {{ site.sched.interactive }} {{ site.sched.flag.interactive }}
 ```
-{: .bash}
+{: .language-bash}
 
 All `{{ site.sched.submit.name }}` options are supported like regular job submission with the difference that with
 `{{ site.sched.interactive }}` they must be given at the command line, and not with any job script. Once a

--- a/reference.md
+++ b/reference.md
@@ -39,14 +39,14 @@ example, instead of showing the transfer rate in real time, the following comman
 rsync: link_stat "/home/{{ site.local.user }}/—progress" failed: No such file or directory (2)
 rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1207) [sender=3.1.3]
 ```
-{: .bash}
+{: .language-bash}
 
 The correct command, different only by two characters, succeeds:
 
 ```
 {{ site.local.prompt }} rsync --progress my_precious_data.txt {{ site.remote.user }}@{{ site.remote.login }}
 ```
-{: .bash}
+{: .language-bash}
 
 We have done our best to wrap all commands in code blocks, which prevents this subtle conversion. If
 you encounter this error, please open an issue or pull request on the lesson repository to help
@@ -62,7 +62,7 @@ the same way as SSH:
 ```
 {{ site.local.prompt }} sftp yourUsername@remote.computer.address
 ```
-{: .bash}
+{: .language-bash}
 
 This will start what appears to be a bash shell (though our prompt says `sftp>`). However we only
 have access to a limited number of commands. We can see which commands are available with `help`:
@@ -70,7 +70,7 @@ have access to a limited number of commands. We can see which commands are avail
 ```
 sftp> help
 ```
-{: .bash}
+{: .language-bash}
 ```
 Available commands:
 bye                                Quit sftp
@@ -103,7 +103,7 @@ To show our remote working directory:
 ```
 sftp> pwd
 ```
-{: .bash}
+{: .language-bash}
 ```
 Remote working directory: /global/home/yourUsername
 ```
@@ -114,7 +114,7 @@ To show our local working directory, we add an `l` in front of the command:
 ```
 sftp> lpwd
 ```
-{: .bash}
+{: .language-bash}
 ```
 Local working directory: /home/jeff/Documents/teaching/hpc-intro
 ```
@@ -130,7 +130,7 @@ To upload a file, we type `put some-file.txt` (tab-completion works here).
 ```
 sftp> put config.toml
 ```
-{: .bash}
+{: .language-bash}
 ```
 Uploading config.toml to /global/home/yourUsername/config.toml
 config.toml                                   100%  713     2.4KB/s   00:00 
@@ -142,7 +142,7 @@ To download a file we type `get some-file.txt`:
 ```
 sftp> get config.toml
 ```
-{: .bash}
+{: .language-bash}
 ```
 Fetching /global/home/yourUsername/config.toml to config.toml
 /global/home/yourUsername/config.toml                               100%  713     9.3KB/s   00:00
@@ -156,7 +156,7 @@ present beforehand.
 sftp> mkdir content
 sftp> put -r content/
 ```
-{: .bash}
+{: .language-bash}
 ```
 Uploading content/ to /global/home/yourUsername/content
 Entering content/


### PR DESCRIPTION
Fixes #315 

`{: .bash}` is not actually part of the [Carpentries syntax](https://carpentries.github.io/lesson-example/04-formatting/index.html#formatting-code) and is actually rendering like `{: .source}`. We should be using `{: .language-bash}`.