### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,5 @@
 # Each line is a file pattern followed by one or more owners.
 # The sequence matters: later patterns take precedence.
 
-*  @psteinb @ChristinaLK @tkphd @megan-guidry @reid-a @mikerenfro @annajiat @colinsauze @willfurnass
+# FILES  OWNERS
+*        @annajiat @mikerenfro @ocaisa @psteinb @reid-a @tkphd


### PR DESCRIPTION
The proposed change will auto-assign PR reviews to active members, where the current file lists a few founding members who have been unable to participate recently.