### PR TITLE
center & shrink figure captions

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,11 +1,15 @@
 <figure>
-   {% if include.url != "" %}
-    <a href="{{ include.url }}">
-   {% endif %}
-   <img src="{{ include.file | relative_url}}" style="max-width: {{ include.max-width }};"
-      alt="{{ include.alt | relative_url}}"/>
-   {% if include.url != "" %}
-   </a>
-   {% endif %}
-   <figcaption>{{ include.caption }}</figcaption>
+  {% if include.url != "" %}
+  <a href="{{ include.url }}">
+  {% endif %}
+    <img src="{{ include.file | relative_url}}" style="max-width: {{ include.max-width }};"
+       alt="{{ include.alt | relative_url}}"/>
+  {% if include.url != "" %}
+  </a>
+  {% endif %}
+  <figcaption style="text-align: center">
+    <small>
+      {{ include.caption }}
+    </small>
+  </figcaption>
 </figure>


### PR DESCRIPTION
The `{% include figure.html ...` method has a "caption" field, but text entered there is rendered inline with the surrounding text, creating confusion. This PR centers and shrinks the caption, to make it more visually recognizable as such.