### PR TITLE
Fix snippet inclusion for four task jobscript

### DIFF
--- a/_episodes/16-parallel.md
+++ b/_episodes/16-parallel.md
@@ -540,10 +540,7 @@ Create a submission file, requesting more than one task on a single node:
 ```
 {: .language-bash}
 
-```
 {% include {{ site.snippets }}/parallel/four-tasks-jobscript.snip %}
-```
-{: .output}
 
 Then submit your job. We will use the batch file to set the options,
 rather than the command line.


### PR DESCRIPTION
The code block context is now included in the snippet so should not be in the lesson (currently it is being parsed wrongly, see around https://carpentries-incubator.github.io/hpc-intro/16-parallel/index.html#execute-the-task)