### PR TITLE
Fixing extra spaces after sbatch commands

### DIFF
--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -151,7 +151,7 @@ there is a distinction between running the job through the scheduler and just
 site.sched.submit.name }}` command.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 ```
 {: .language-bash}
 
@@ -179,7 +179,7 @@ interval to a more reasonable value, for example 15 seconds, with the `-n 15`
 parameter. Let's try using it to monitor another job.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -237,7 +237,7 @@ echo "This script has finished successfully."
 Submit the job and monitor its status:
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -315,7 +315,7 @@ later episode of this lesson.
 > > {: .output}
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >
@@ -350,7 +350,7 @@ Submit the job and wait for it to finish. Once it is has finished, check the
 log file.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -378,7 +378,7 @@ its job number (remember to change the walltime so that it runs long enough for
 you to cancel it before it is killed!).
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}

--- a/_episodes/13-scheduler.md
+++ b/_episodes/13-scheduler.md
@@ -151,7 +151,7 @@ there is a distinction between running the job through the scheduler and just
 site.sched.submit.name }}` command.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 ```
 {: .language-bash}
 
@@ -179,7 +179,7 @@ interval to a more reasonable value, for example 15 seconds, with the `-n 15`
 parameter. Let's try using it to monitor another job.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -237,7 +237,7 @@ echo "This script has finished successfully."
 Submit the job and monitor its status:
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -315,7 +315,7 @@ later episode of this lesson.
 > > {: .output}
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >
@@ -350,7 +350,7 @@ Submit the job and wait for it to finish. Once it is has finished, check the
 log file.
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 {{ site.remote.prompt }} watch -n 15 {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}
@@ -378,7 +378,7 @@ its job number (remember to change the walltime so that it runs long enough for
 you to cancel it before it is killed!).
 
 ```
-{{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+{{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 {{ site.remote.prompt }} {{ site.sched.status }} {{ site.sched.flag.user }}
 ```
 {: .language-bash}

--- a/_episodes/14-modules.md
+++ b/_episodes/14-modules.md
@@ -193,7 +193,7 @@ Let's examine the output of `module avail` more closely.
 > > {: .output}
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} python-module.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}python-module.sh
 > > ```
 > > {: .language-bash}
 > {: .solution}

--- a/_episodes/14-modules.md
+++ b/_episodes/14-modules.md
@@ -193,7 +193,7 @@ Let's examine the output of `module avail` more closely.
 > > {: .output}
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}python-module.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}python-module.sh
 > > ```
 > > {: .language-bash}
 > {: .solution}

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
@@ -12,8 +12,8 @@
 > >
 > > ```
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,7 +11,7 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```

--- a/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/ComputeCanada_Graham_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,9 +11,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/Magic_Castle_EESSI_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/Magic_Castle_EESSI_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,9 +11,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/Magic_Castle_EESSI_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/Magic_Castle_EESSI_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,9 +11,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,9 +11,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/NIST_CTCMS_slurm/scheduler/terminate-multiple-jobs.snip
@@ -11,9 +11,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
@@ -12,9 +12,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %}{{ site.sched.submit.options }} {% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >

--- a/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
+++ b/_includes/snippets_library/UCL_Myriad_sge/scheduler/terminate-multiple-jobs.snip
@@ -12,9 +12,9 @@
 > > First, submit a trio of jobs:
 > >
 > > ```
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
-> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {{ site.sched.submit.options }} example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
+> > {{ site.remote.prompt }} {{ site.sched.submit.name }} {% if site.sched.submit.options != '' %} {{ site.sched.submit.options }}{% endif %}example-job.sh
 > > ```
 > > {: .language-bash}
 > >


### PR DESCRIPTION
Extra spaces due to the `site.sched.submit.options` variable being empty for many of the sites. This does clutter up the templates a bit, but not sure if we have any better options other than living with the extra spaces.