### PR TITLE
De-italicize i.e. and e.g.

### DIFF
--- a/_episodes/18-responsibility.md
+++ b/_episodes/18-responsibility.md
@@ -123,7 +123,7 @@ that have short wait times to help you avoid this issue.
 ## Have a backup plan
 
 Although many HPC systems keep backups, it does not always cover all the file
-systems available and may only be for disaster recovery purposes (*i.e.* for
+systems available and may only be for disaster recovery purposes (i.e. for
 restoring the whole file system if lost rather than an individual file or
 directory you have deleted by mistake). Protecting critical data from
 corruption or deletion is primarily your responsibility: keep your own backup

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -19,7 +19,7 @@ is a great way to contribute.
 [Central processing unit](https://en.wikipedia.org/wiki/CPU)
 :     or simply *processor* is the (hardware) component of a computer that
       executes the instructions supplied by a program (software). Most modern
-      desktop computers have multi-core processors *e.g.* devices with 2 CPUs
+      desktop computers have multi-core processors e.g. devices with 2 CPUs
       are called dual-core, with 4 cores are called quad-core and so on. Each
       **core** is a separate physical implementation of the electronic
       circuitry required to execute instructions.
@@ -29,8 +29,8 @@ is a great way to contribute.
 
 [Cluster](https://en.wikipedia.org/wiki/Computer_cluster)
 :     a collection of computers configured to enable collaboration on a common
-      task by means of purposefully configured hardware (*e.g.*, networking)
-      and software (*e.g.* workload management).
+      task by means of purposefully configured hardware (e.g., networking)
+      and software (e.g. workload management).
 
 [Distributed memory](https://en.wikipedia.org/wiki/Distributed_memory)
 :    *to be defined*

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -19,7 +19,7 @@ is a great way to contribute.
 [Central processing unit](https://en.wikipedia.org/wiki/CPU)
 :     or simply *processor* is the (hardware) component of a computer that
       executes the instructions supplied by a program (software). Most modern
-      desktop computers have multi-core processors e.g. devices with 2 CPUs
+      desktop computers have multi-core processors, e.g. devices with 2 CPUs
       are called dual-core, with 4 cores are called quad-core and so on. Each
       **core** is a separate physical implementation of the electronic
       circuitry required to execute instructions.


### PR DESCRIPTION
Though [this old English StackExchange answer](https://english.stackexchange.com/a/3916) indicates "opinion is mixed" on italicizing these, it looks like their citation of Wiktionary is now out of date, and it's hard to find references for people who want to italicize it. Today I Learned.