### PR TITLE
Removed mention of bash in Episode 11

### DIFF
--- a/_episodes/11-hpc-intro.md
+++ b/_episodes/11-hpc-intro.md
@@ -14,7 +14,7 @@ keypoints:
 - "These other systems can be used to do work that would either be impossible
   or much slower on smaller systems."
 - "The standard method of interacting with such systems is via a command line
-  interface called Bash."
+  interface."
 ---
 
 Frequently, research problems that use computing can outgrow the capabilities


### PR DESCRIPTION
The lesson's key points are correct and match the lesson's content. I believe bash should be removed from the key points since it was not used in the specific episode. For a brief introduction, it would be best to keep it as a simple difference between CLI and GUI until bash is needed in later episodes' examples when running different jobs.

For the key points review in #116 
