### PR TITLE
Add site.url and site.baseurl to some images

### DIFF
--- a/_episodes/11-hpc-intro.md
+++ b/_episodes/11-hpc-intro.md
@@ -62,7 +62,7 @@ problems in parallel**.
 
 ## Jargon Busting Presentation
 
-Open the [HPC Jargon Buster]({{ site.baseurl }}/files/jargon.html#p1) in
+Open the [HPC Jargon Buster]({{ site.url }}{{ site.baseurl }}/files/jargon.html#p1) in
 a new tab. To present the content, press `C` to open a **c**lone in
 a separate window, then press `P` to toggle presentation mode.
 

--- a/_includes/all_figures.html
+++ b/_includes/all_figures.html
@@ -1,27 +1,27 @@
-<p><img alt="" src="../fig/filesystem-challenge.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/filesystem-challenge.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/filesystem-challenge.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/filesystem-challenge.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/filesystem.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/filesystem.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/filesystem.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/filesystem.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/find-file-tree.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/find-file-tree.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/find-file-tree.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/find-file-tree.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/home-directories.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/home-directories.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/home-directories.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/home-directories.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/homedir.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/homedir.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/linux-cloud.jpg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/linux-cloud.jpg" /></p>
 <hr/>
-<p><img alt="" src="../fig/nano-screenshot.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/nano-screenshot.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/redirects-and-pipes.png" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/redirects-and-pipes.png" /></p>
 <hr/>
-<p><img alt="" src="../fig/redirects-and-pipes.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/redirects-and-pipes.svg" /></p>
 <hr/>
-<p><img alt="" src="../fig/responsibility-bandwidth.svg" /></p>
+<p><img alt="" src="{{ site.url }}{{ site.baseurl }}../fig/responsibility-bandwidth.svg" /></p>


### PR DESCRIPTION
When rendering the page in a platform other than GitHub, the images were not being shown.

This is something that has been solved in more recent versions of the carpentry template using `{{ relative_root_path }}` but this functionality isn't available in the current template.