### PR TITLE
Fix emphasis of single characters

### DIFF
--- a/_episodes/10-hpc-intro.md
+++ b/_episodes/10-hpc-intro.md
@@ -55,8 +55,8 @@ problems in parallel__.
 ## Jargon Busting Presentation
 
 Open the [HPC Jargon Buster]({{ site.url }}{{ site.baseurl }}/files/jargon.html#p1)
-in a new tab. To present the content, press `C` to open a __c__lone in a
-separate window, then press `P` to toggle presentation mode.
+in a new tab. To present the content, press `C` to open a **c**lone in a
+separate window, then press `P` to toggle **p**resentation mode.
 
 > ## I've Never Used a Server, Have I?
 >

--- a/_episodes/11-connecting.md
+++ b/_episodes/11-connecting.md
@@ -302,7 +302,7 @@ See the [PuTTY documentation][putty-agent].
 {% if site.remote.portal %}
 Visit {{ site.remote.portal }} to upload your SSH public key.
 {% else %}
-Use the __s__ecure __c__o__p__y tool to send your public key to the cluster.
+Use the **s**ecure **c**o**p**y tool to send your public key to the cluster.
 
 ```
 {{ site.local.prompt }} scp ~/.ssh/id_ed25519.pub {{ site.remote.user }}@{{ site.remote.login }}:~/
@@ -362,7 +362,7 @@ may also notice that the current hostname is also part of our prompt!)
 {: .output}
 
 So, we're definitely on the remote machine. Next, let's find out where we are
-by running `pwd` to __p__rint the __w__orking __d__irectory.
+by running `pwd` to **p**rint the **w**orking **d**irectory.
 
 ```
 {{ site.remote.prompt }} pwd

--- a/_episodes/12-cluster.md
+++ b/_episodes/12-cluster.md
@@ -250,9 +250,9 @@ connect to a shared, remote fileserver or cluster of servers.
 > > ```
 > > {: .language-bash}
 > >
-> > You can also explore the available filesystems using `df` to show __d__isk
-> > __f__ree space. The `-h` flag renders the sizes in a human-friendly format,
-> > i.e., GB instead of B. The __t__ype flag `-T` shows what kind of filesystem
+> > You can also explore the available filesystems using `df` to show **d**isk
+> > **f**ree space. The `-h` flag renders the sizes in a human-friendly format,
+> > i.e., GB instead of B. The **t**ype flag `-T` shows what kind of filesystem
 > > each resource is.
 > >
 > > ```

--- a/_episodes/15-transferring-files.md
+++ b/_episodes/15-transferring-files.md
@@ -119,7 +119,7 @@ command to upload it to the cluster.
 > {: .challenge}
 {: .discussion}
 
-To copy a whole directory, we add the `-r` flag, for "__r__ecursive": copy the
+To copy a whole directory, we add the `-r` flag, for "**r**ecursive": copy the
 item specified, and every item below it, and every item below those... until it
 reaches the bottom of the directory tree rooted at the folder name you
 provided.
@@ -283,7 +283,7 @@ Let's start with the file we downloaded from the lesson site,
 compression library. Reading this file name, it appears somebody took a folder
 named "hpc-lesson-data," wrapped up all its contents in a single file with
 `tar`, then compressed that archive with `gzip` to save space. Let's check
-using `tar` with the `-t` flag, which prints the "__t__able of contents"
+using `tar` with the `-t` flag, which prints the "**t**able of contents"
 without unpacking the file, specified by `-f <filename>`, on the remote
 computer. Note that you can concatenate the two flags, instead of writing
 `-t -f` separately.
@@ -317,8 +317,8 @@ hpc-intro-data/north-pacific-gyre/NENE02040Z.txt
 
 This shows a folder containing another folder, which contains a bunch of files.
 If you've taken The Carpentries' Shell lesson recently, these might look
-familiar. Let's see about that compression, using `du` for "__d__isk
-__u__sage".
+familiar. Let's see about that compression, using `du` for "**d**isk
+**u**sage".
 
 ```
 {{ site.remote.prompt }} du -sh hpc-lesson-data.tar.gz
@@ -334,9 +334,9 @@ __u__sage".
 
 Now let's unpack the archive. We'll run `tar` with a few common flags:
 
-* `-x` to e__x__tract the archive
-* `-v` for __v__erbose output
-* `-z` for g__z__ip compression
+* `-x` to e**x**tract the archive
+* `-v` for **v**erbose output
+* `-z` for g**z**ip compression
 * `-f` for the file to be unpacked
 
 When it's done, check the directory size with `du` and compare.

--- a/_episodes/16-parallel.md
+++ b/_episodes/16-parallel.md
@@ -31,7 +31,7 @@ The program generates a large number of random points on a 1×1 square
 centered on (½,½), and checks how many of these points fall
 inside the unit circle.
 On average, π/4 of the randomly-selected points should fall in the
-circle, so π can be estimated from 4_f_, where _f_ is the observed
+circle, so π can be estimated from 4*f*, where _f_ is the observed
 fraction of points that fall in the circle.
 Because each sample is independent, this algorithm is easily implemented
 in parallel.


### PR DESCRIPTION
Apparently, Markdown parsers do not properly interpret __strong__ emphasis in
the middle of a word. This commit addresses this by replacing `__` with `**`,
per the recommended strategy:
<https://www.markdownguide.org/basic-syntax#bold-best-practices>