### PR TITLE
Typo fix for README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ provided to help guide planning and decision-making.
 
 1. [Working with the scheduler](_episodes/13-scheduler.md) (1 hour 15 minutes)
 
-   * Know how to submit a program and batch scrip to the cluster (interactive &
+   * Know how to submit a program and batch script to the cluster (interactive &
      batch)
    * Use the batch system command line tools to monitor the execution of your
      job.


### PR DESCRIPTION
This is slightly mysterious -- it *is* an actual error, "script" is meant there, but it's apparently been accepted by the CI for a long time, but now is not being accepted.  "Scrip" is a perfectly legitimate English word, though not what is meant here, so the CI rejection is a bit puzzling also. Maybe the dictionary changed?