### PR TITLE
Make sure `sacct` job output is not wrapped in `less`

### DIFF
--- a/_episodes/17-resources.md
+++ b/_episodes/17-resources.md
@@ -74,7 +74,7 @@ information to `less` to make it easier to view (use the left and right arrow
 keys to scroll through fields).
 
 ```
-{{ site.remote.prompt }} {{ site.sched.hist }} {{ site.sched.flag.histdetail }} 347087 | less
+{{ site.remote.prompt }} {{ site.sched.hist }} {{ site.sched.flag.histdetail }} 347087 | less -S
 ```
 {: .language-bash}
 


### PR DESCRIPTION
I needed to use `less -S`, otherwise less (v. 530) would wrap the text, making it impossible to read.