### PR TITLE
Rsync's behavior when uploading a directory

### DIFF
--- a/_episodes/16-transferring-files.md
+++ b/_episodes/16-transferring-files.md
@@ -340,8 +340,9 @@ If your home directory _is_ the destination, you can leave the destination
 field blank, or type `~` -- the shorthand for your home directory -- for
 completeness.
 
-With `scp`, a trailing slash on the target directory is optional, and has
-no effect. It is important for other commands, like `rsync`.
+With `scp`, directories can be uploaded using the `-r` option. A trailing
+slash on a source directory is optional, and has no effect. It is important
+for other commands, like `rsync`.
 
 > ## A Note on `rsync`
 >
@@ -375,10 +376,10 @@ no effect. It is important for other commands, like `rsync`.
 > {: .language-bash}
 >
 > As written, this will place the local directory and its contents under your
-> home directory on the remote system. If the trailing slash is omitted on
-> the destination, a new directory corresponding to the transferred directory
-> will not be created, and the contents of the source
-> directory will be copied directly into the destination directory.
+> home directory on the remote system. If a trailing slash is added to the
+> source, a new directory corresponding to the transferred directory
+> will not be created, and the contents of the source directory will be
+> copied directly into the destination directory.
 >
 > To download a file, we simply change the source and destination:
 >

--- a/_episodes/16-transferring-files.md
+++ b/_episodes/16-transferring-files.md
@@ -340,9 +340,8 @@ If your home directory _is_ the destination, you can leave the destination
 field blank, or type `~` -- the shorthand for your home directory -- for
 completeness.
 
-With `scp`, directories can be uploaded using the `-r` option. A trailing
-slash on a source directory is optional, and has no effect. It is important
-for other commands, like `rsync`.
+With `scp`, a trailing slash on the target directory is optional, and has no effect.
+A trailing slash on a source directory is important for other commands, like `rsync`.
 
 > ## A Note on `rsync`
 >


### PR DESCRIPTION
Rsync does not behave as described in this paragraph. I have set up an illustrating example for clarity.

These are my starting points on my local machine (a directory `bar` containing a file `subbar`) and the remote cluster.

Local:
```
$ ls -ld bar
drwxr-xr-x  3 ccaech0  staff  96 25 Jul 11:54 bar
$ ls -l bar 
total 0
-rw-r--r--  1 ccaech0  staff  0 25 Jul 11:54 subbar
```

Remote:
```
myriad $ ls -l bar subbar
ls: cannot access bar: No such file or directory
ls: cannot access subbar: No such file or directory
```

The example of L373 works as written.
Local:
```
$ rsync -avP bar myriad:~/
building file list ... 
2 files to consider
bar/
bar/subbar
           0 100%    0.00kB/s    0:00:00 (xfer#1, to-check=0/2)

sent 142 bytes  received 48 bytes  42.22 bytes/sec
total size is 0  speedup is 0.00
```

Remote:
```
myriad $ ls -l bar subbar
ls: cannot access subbar: No such file or directory
bar:
total 0
-rw-r--r-- 1 ccaech0 staff 0 Jul 25 11:54 subbar
myriad $ rm -rf bar subbar
```

Regarding the paragraph starting on L377, Rsync behaves identically if the trailing `/` on the target directory is omitted.

Local:
```
$ rsync -avP bar myriad:~ 
building file list ... 
2 files to consider
bar/
bar/subbar
           0 100%    0.00kB/s    0:00:00 (xfer#1, to-check=0/2)

sent 142 bytes  received 48 bytes  126.67 bytes/sec
total size is 0  speedup is 0.00
```

Remote:
```
$ ls -l bar subbar
ls: cannot access subbar: No such file or directory
bar:
total 0
-rw-r--r-- 1 ccaech0 staff 0 Jul 25 11:54 subbar
myriad $ rm -rf bar subbar
```

However, adding a trailing `/` on the source directory will result in the behaviour described.

Local:
```
$ rsync -avP bar/ myriad:~/
building file list ... 
2 files to consider
./
subbar
           0 100%    0.00kB/s    0:00:00 (xfer#1, to-check=0/2)

sent 138 bytes  received 48 bytes  74.40 bytes/sec
total size is 0  speedup is 0.00
```

Remote:
```
$ ls -l bar subbar
ls: cannot access bar: No such file or directory
-rw-r--r-- 1 ccaech0 staff 0 Jul 25 11:54 subbar
```

We have updated the text in the lesson to clarify this.