### PR TITLE
Modified the global config to comment out the array lesson.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,8 @@ episodes:
   - 14-environment-variables.Rmd
   - 15-modules.Rmd
   - 16-transferring-files.Rmd
-  - 21-array.Rmd
+# Restore after issue #482 is addressed.
+#   - 21-array.Rmd
   - 17-parallel.Rmd
   - 18-resources.Rmd
   - 19-responsibility.Rmd


### PR DESCRIPTION
Can be restored once Issue #482 (templating for this lesson) is resolved

The purpose of this is, it's a simple way to keep the public repo in a functional state, without reverting the merge of PR #481. 