### PR TITLE
Drop array lesson

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,8 +72,6 @@ episodes:
   - 14-environment-variables.Rmd
   - 15-modules.Rmd
   - 16-transferring-files.Rmd
-# Restore after issue #482 is addressed.
-#   - 21-array.Rmd
   - 17-parallel.Rmd
   - 18-resources.Rmd
   - 19-responsibility.Rmd


### PR DESCRIPTION
This simple PR drops the JobArray lesson from the top-level config.